### PR TITLE
Fix recurent port not free

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,1 @@
+unittest2

--- a/test/setup_module_test.sh
+++ b/test/setup_module_test.sh
@@ -24,6 +24,7 @@ git clone https://github.com/naparuba/shinken.git ~/shinken
 
 [ -f test/dep_modules.txt ] && setup_submodule
 [ -f requirements.txt ] && pip install -r requirements.txt
+[ -f test/requirements.txt ] && pip install -r test/requirements.txt
 
 # if we have test config files we probably also need them in the shinken/test directory :
 [ -d test/etc ] && cp -r test/etc ~/shinken/test/

--- a/test/test_livestatus_mongodb.py
+++ b/test/test_livestatus_mongodb.py
@@ -35,12 +35,12 @@ import re
 import subprocess
 import time
 import random
-import unittest
+
 
 #sys.path.append('../shinken/modules')
 
 from shinken_modules import ShinkenModulesTest
-from shinken_test import time_hacker
+from shinken_test import time_hacker, unittest
 
 from shinken.modulesctx import modulesctx
 from shinken.objects.module import Module


### PR DESCRIPTION
I don't really get how the port could be not free from time to time **unless** the network namespace is shared with others travis test instances which could also use that port.

anyway now we'll be more safe (normally always) with this automatic random port selection.
