### PR TITLE
Switch to mongoclient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymongo<3
+pymongo>1


### PR DESCRIPTION
Updated module to use the MongoClient way of talking to MongoDB. Tested with pymongo 2.6.2 and 3.0.1 against MongoDB 2.6.9