### PR TITLE
Fix make_mongo_filter

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -301,10 +301,10 @@ class LiveStatusLogStoreMongoDB(BaseModule):
         # The filters are text fragments which are put together to form a sql where-condition finally.
         # Add parameter Class (Host, Service), lookup datatype (default string), convert reference
         # which attributes are suitable for a sql statement
-        good_attributes = ['time', 'attempt', 'logclass', 'command_name', 'comment', 'contact_name', 'host_name', 'plugin_output', 'service_description', 'state', 'state_type', 'type']
+        good_attributes = ['time', 'attempt', 'logclass', 'command_name', 'comment', 'contact_name', 'message', 'host_name', 'plugin_output', 'service_description', 'state', 'state_type', 'type']
         good_operators = ['=', '!=']
         #  put strings in '' for the query
-        string_attributes = ['command_name', 'comment', 'contact_name', 'host_name', 'plugin_output', 'service_description', 'state_type', 'type']
+        string_attributes = ['command_name', 'comment', 'contact_name', 'host_name', 'message', 'plugin_output', 'service_description', 'state_type', 'type']
         if attribute in string_attributes:
             reference = "'%s'" % reference
 


### PR DESCRIPTION
I'll log an issue with all the details. Suffice it to say here: the arribute 'message' was missing in the 'good_attributes' and 'string_attributes' lists, which caused this module to get _all_ logs from mongodb as it generated a wrong filter when using the reporting functionality in Thruk instead of the relevant logs.
It used to get several tens of thousands of log entries, on which this module choked later on. This doesn't solve the choking, but it does make sure that it only grabs the relevant logs and as long as that's a not insane amount, it can be processes just fine. My test reports which reliably always broke this module now work just fine.