### PR TITLE
filter works with new loglevel

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -203,7 +203,7 @@ class LiveStatusLogStoreMongoDB(BaseModule):
     def manage_log_brok(self, b):
         data = b.data
         line = data['log']
-        if re.match("^\[[0-9]*\] [A-Z][a-z]*.:", line):
+        if re.match("^\[[0-9]*\] [A-Z][a-z]*.:", line, re.I):
             # Match log which NOT have to be stored
             # print "Unexpected in manage_log_brok", line
             return


### PR DESCRIPTION
The log level displayed in each log line was changed in 2.4 to use the standard loglevel format of all uppercase.  This patch will make the log filter work with both the old and new log level formats.