### PR TITLE
Fix concurrency issues when multiple threads send queries to the database

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -127,10 +127,6 @@ class LiveStatusLogStoreMongoDB(BaseModule):
                 self.max_logs_age = int(maxmatch.group(1)) * 365
         self.use_aggressive_sql = (getattr(modconf, 'use_aggressive_sql', '1') == '1')
         # This stack is used to create a full-blown select-statement
-        self.mongo_filter_stack = LiveStatusMongoStack()
-        # This stack is used to create a minimal select-statement which
-        # selects only by time >= and time <=
-        self.mongo_time_filter_stack = LiveStatusMongoStack()
         self.is_connected = DISCONNECTED
         self.backlog = []
         # Now sleep one second, so that won't get lineno collisions with the last second
@@ -144,6 +140,10 @@ class LiveStatusLogStoreMongoDB(BaseModule):
         pass
 
     def open(self):
+        self.mongo_filter_stack = LiveStatusMongoStack()
+        # This stack is used to create a minimal select-statement which
+        # selects only by time >= and time <=
+        self.mongo_time_filter_stack = LiveStatusMongoStack()
         try:
             if self.replica_set:
                 self.conn = pymongo.ReplicaSetConnection(self.mongodb_uri, replicaSet=self.replica_set, fsync=self.mongodb_fsync)

--- a/module/module.py
+++ b/module/module.py
@@ -126,7 +126,6 @@ class LiveStatusLogStoreMongoDB(BaseModule):
             elif maxmatch.group(2) == 'y':
                 self.max_logs_age = int(maxmatch.group(1)) * 365
         self.use_aggressive_sql = (getattr(modconf, 'use_aggressive_sql', '1') == '1')
-        # This stack is used to create a full-blown select-statement
         self.is_connected = DISCONNECTED
         self.backlog = []
         # Now sleep one second, so that won't get lineno collisions with the last second
@@ -140,6 +139,7 @@ class LiveStatusLogStoreMongoDB(BaseModule):
         pass
 
     def open(self):
+        # This stack is used to create a full-blown select-statement
         self.mongo_filter_stack = LiveStatusMongoStack()
         # This stack is used to create a minimal select-statement which
         # selects only by time >= and time <=


### PR DESCRIPTION
This pull requests move the filter stack initializations to the `open` method to avoid some concurrency issues. We noticed this bug when queries with no filters were sent to our MongoDB log collection, causing high memory consumption by the broker and stability issues in the server where shinken is running.

It's the same issue we had a few months ago in shinken-monitoring/mod-logstore-sqlite#16: each connection handled by mod-livestatus copies the logstore into the connection thread. But because it uses `copy.copy`,every thread will share the same stack, because only the reference to the same heap object is copied.

As a consequence, if two connection threads, let's call them A and B, are able to be handled by mod-livestatus at the same time, each thread will push filters to the same stack. The first thread that sends the query will pop from the stack filters from both A and B, producing redundant filters in the query, and the second one will pop no filters, producing a query with no filters, which will yield wrong data and will cause higher CPU usage as more data is received by the broker.